### PR TITLE
Improvements for proper installing app

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,7 @@
 {
+    "autoload": {
+        "psr-4": { "DreamCommerce\\": "vendor/dreamcommerce/shop-appstore-lib/src/DreamCommerce/" }
+    },
     "repositories": [{
         "type": "package",
         "package": {

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,16 @@
 {
+    "repositories": [{
+        "type": "package",
+        "package": {
+            "name": "dreamcommerce/shop-appstore-lib",
+            "version": "master",
+            "source": {
+                "url": "https://github.com/dreamcommerce/shop-appstore-lib.git",
+                "type": "git",
+                "reference": "master"
+            }
+        }
+    }],
     "scripts": {
         "post-package-install": [
             "php -r \"file_put_contents('src/bootstrap.php', str_replace('//require \\'vendor/autoload.php\\';', 'require \\'vendor/autoload.php\\';', file_get_contents('src/bootstrap.php')));\""

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -9,7 +9,9 @@ if (PHP_VERSION_ID < 50600) {
 // internal autoloader
 spl_autoload_register(function($class){
     $class = str_replace('\\', '/', $class);
-    require 'src/'.$class.'.php';
+    if (file_exists('src/'.$class.'.php')) {
+        require 'src/'.$class.'.php';
+    }
 });
 
 // composer autoloader - patched automatically


### PR DESCRIPTION
It fixes two problems: 
- it adds Dreamcommerce's repo into composer.json file. Without that I can't download dreamcommerce/shop-appstore-lib, as it wasn't known to Packagist;
- configures PSR-4 autoloading to proper search for classes. I have to add it, as it wasn't looking for required classes (ie. it wasn't loading class DreamCommerce\Handler when requested in src/BillingSystem/App.php).
